### PR TITLE
Support IsAzure option of ChatGpt LLM by AITuber controller

### DIFF
--- a/chatdollkit_aituber/api.py
+++ b/chatdollkit_aituber/api.py
@@ -124,11 +124,13 @@ def get_router(client: ChatdollKitClient) -> APIRouter:
         model: str = "gpt-4o",
         temperature: float = 0.5,
         url: str = None,
-        user: str = None
+        user: str = None,
+        is_azure: bool = False
     ):
         client.llm("activate", data={
             "name": name, "api_key": api_key, "model": model,
-            "temperature": temperature, "url": url, "user": user
+            "temperature": temperature, "url": url, "user": user,
+            "is_azure": is_azure
         })
         return JSONResponse(content={"result": "success"})
 


### PR DESCRIPTION
Currently, AITuber controller cannot configure LLM of the Azure OpenAI Service. The ChatGPT LLM Service has an IsAzure option, This PR can probably configure IsAzure option from the Controller using is_azure argument.

see also: https://github.com/uezo/ChatdollKit/pull/413